### PR TITLE
chore: delete default D-badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Team-269-Backend
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/27dcc4acfa9c4d8f95f058acd398a058)](https://app.codacy.com/gh/BuildForSDG/Team-269-Backend?utm_source=github.com&utm_medium=referral&utm_content=BuildForSDG/Team-269-Backend&utm_campaign=Badge_Grade_Settings)
-[![Codacy Badge](https://img.shields.io/badge/Code%20Quality-D-red)](https://img.shields.io/badge/Code%20Quality-D-red)
 
 API for data collection app to measure proportion of urban population living in slums, informal settlements or inadequate housing
 


### PR DESCRIPTION
## Description
Please include a summary of the change and relevant motivation and context. 
Basically deletes the redundant default badge with D-rating from the back-end readme

Fixes #(  Issue  #11) 

## How Has This Been Tested?
It's a delete so it can be seen visibly by the D-Badge disappearing on the current branch.

## Screenshots 
Back end Readme was having two badges before this PR
![Screenshot from 2020-05-20 13-06-21](https://user-images.githubusercontent.com/36065782/82433897-c6d96b00-9a9a-11ea-9ca1-25e23ee2c510.png)



## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [x ] New and existing unit tests pass locally with my changes
